### PR TITLE
Fix: Add validation for MONGO_URI and document environment variable fix

### DIFF
--- a/extensions.py
+++ b/extensions.py
@@ -18,5 +18,9 @@ scheduler = APScheduler()
 MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost:27017")
 MONGO_DB_NAME = os.getenv("MONGO_DB_NAME", "collective_rcm")
 
+if not (MONGO_URI.startswith("mongodb://") or MONGO_URI.startswith("mongodb+srv://")):
+    print(f"Error: Invalid MONGO_URI: '{MONGO_URI}'. Falling back to default URI: mongodb://localhost:27017/{MONGO_DB_NAME}")
+    MONGO_URI = f"mongodb://localhost:27017/{MONGO_DB_NAME}"
+
 mongo_client = MongoClient(MONGO_URI)
 mongo_db = mongo_client[MONGO_DB_NAME]


### PR DESCRIPTION
Adds a validation step in `extensions.py` to check if the `MONGO_URI` starts with the required "mongodb://" or "mongodb+srv://" schemes.

If an invalid URI is detected (likely from an environment variable), an error message is printed, and the application falls back to a default local MongoDB URI ("mongodb://localhost:27017/collective_rcm") to prevent crashing.

This also serves to document the necessary fix in the deployment environment where the MONGO_URI environment variable must be correctly configured.