### PR TITLE
Fix: Track special exam incorrect answers

### DIFF
--- a/admin_routes.py
+++ b/admin_routes.py
@@ -1551,9 +1551,15 @@ def view_incorrect_answers():
     detailed_q = (
         db.session.query(
             last_wrong_sq.c.last_wrong.label('answered_at'),
-            Exam.title.label('exam_title'),
+            db.case(
+                [
+                    (IncorrectAnswer.special_paper.isnot(None),
+                     db.func.concat('Special Exam ', IncorrectAnswer.special_paper))
+                ],
+                else_=Exam.title
+            ).label('exam_title'),
             IncorrectAnswer.special_paper,
-            Question.id.label('question_id'),
+            IncorrectAnswer.question_id.label('question_id_val'), # Renamed to avoid clash if Question.id is also selected
             Question.question_text,
             IncorrectAnswer.user_answer,
             IncorrectAnswer.correct_answer
@@ -1561,13 +1567,14 @@ def view_incorrect_answers():
         .join(
             IncorrectAnswer,
             and_(
-                IncorrectAnswer.question_id == last_wrong_sq.c.question_id,
+                IncorrectAnswer.question_id == last_wrong_sq.c.question_id, # This uses the question_id from IncorrectAnswer via last_wrong_sq
                 IncorrectAnswer.answered_at  == last_wrong_sq.c.last_wrong
             )
         )
-        .join(Question, IncorrectAnswer.question_id == Question.id)
-        .outerjoin(Exam,   IncorrectAnswer.exam_id       == Exam.id)
-        # sort by the subquery’s max timestamp
+        # OUTER JOIN to Question table using IncorrectAnswer.question_id
+        .outerjoin(Question, IncorrectAnswer.question_id == Question.id)
+        # OUTER JOIN to Exam table
+        .outerjoin(Exam, IncorrectAnswer.exam_id == Exam.id)
         .order_by(desc(last_wrong_sq.c.last_wrong))
     )
 

--- a/special_exams_routes.py
+++ b/special_exams_routes.py
@@ -153,7 +153,7 @@ def submit_paper1():
             if raw.lower() != ans:
                 db.session.add(IncorrectAnswer(
                     user_id        = current_user.id,
-                    exam_id        = ACCESS_ID,
+                    exam_id        = None,
                     special_paper  = 'paper1',
                     question_id    = int(q),
                     user_answer    = raw,
@@ -328,7 +328,7 @@ def submit_paper2():
             if raw.lower() != ans:
                 db.session.add(IncorrectAnswer(
                     user_id        = current_user.id,
-                    exam_id        = ACCESS_ID,
+                    exam_id        = None,
                     special_paper  = 'paper2',
                     question_id    = int(q),
                     user_answer    = raw,

--- a/templates/incorrect_details.html
+++ b/templates/incorrect_details.html
@@ -27,12 +27,15 @@ Incorrect Answers{% endblock %} {% block content %}
         {% for r in records %}
         <tr>
           <td>{{ r.answered_at.strftime('%Y-%m-%d %H:%M') }}</td>
+          <td>{{ r.exam_title }}</td>
+          <td>{{ r.question_id_val }}</td>
           <td>
-            {% if r.exam_title %} {{ r.exam_title }} {% elif r.special_paper %}
-            Special {{ r.special_paper|capitalize }} {% else %} – {% endif %}
+            {% if r.question_text %}
+              {{ r.question_text }}
+            {% else %}
+              N/A (Special Exam Question)
+            {% endif %}
           </td>
-          <td>{{ r.question_id }}</td>
-          <td>{{ r.question_text }}</td>
           <td>{{ r.user_answer }}</td>
           <td>{{ r.correct_answer }}</td>
         </tr>


### PR DESCRIPTION
Implements a comprehensive solution to track and display incorrect answers for special exams (Paper1 and Paper2) without modifying the Exam table.

Key changes:
- Modified `special_exams_routes.py` to set `exam_id=None` and correctly populate `special_paper` when storing incorrect answers for special exams.
- Adjusted `admin_routes.py` in the `view_incorrect_answers` function:
    - The query now uses an `OUTER JOIN` to the `Exam` table to include special exam answers (where `exam_id` is None).
    - Dynamically generates `exam_title` using `db.case`, displaying "Special Exam paper1/paper2" for special exams or `Exam.title` for regular exams.
    - Uses an `OUTER JOIN` to the `Question` table to fetch question text, allowing for cases where special exam questions don't have entries in the `Question` table.
- Updated `templates/incorrect_details.html`:
    - Simplified exam title display to use the new dynamic `exam_title`.
    - Displays actual question text for regular exams and "N/A (Special Exam Question)" for special exams, with the question ID (0-39) displayed in the "Q-ID" column.

This ensures that incorrect answers from both regular and special exams are correctly recorded and are visible in the admin reports with appropriate titles and details.