### PR TITLE
Fix: Resolve 500 error in incorrect answers view and unsaved changes …

### DIFF
--- a/templates/exam_paper1.html
+++ b/templates/exam_paper1.html
@@ -2581,13 +2581,24 @@
             }
           });
 
+          // Add event listener for form submission
+          if (form) { // Ensure form element exists
+            form.addEventListener('submit', function() {
+              submitted = true; // Set submitted to true when the form submission process begins
+              if (timeInp) { // Ensure timeInp element exists (timeSpentInput)
+                // Calculate time spent, assuming 'remaining' is in seconds and total time was 60*60
+                timeInp.value = (60 * 60 - remaining);
+              }
+            });
+          }
+
           // beforeunload → sendBeacon + warning
           window.addEventListener("beforeunload", (e) => {
             if (!submitted) {
               const fd = new FormData(form);
               fd.append("time_spent", 60 * 60 - remaining);
               navigator.sendBeacon(form.action, fd);
-              e.preventDefault();
+              e.preventDefault(); // This triggers the warning
               e.returnValue = "";
             }
           });

--- a/templates/exam_paper2.html
+++ b/templates/exam_paper2.html
@@ -2554,13 +2554,24 @@
             }
           });
 
+          // Add event listener for form submission
+          if (form) { // Ensure form element exists
+            form.addEventListener('submit', function() {
+              submitted = true; // Set submitted to true when the form submission process begins
+              if (timeInp) { // Ensure timeInp element exists (timeSpentInput)
+                // Calculate time spent, assuming 'remaining' is in seconds and total time was 60*60
+                timeInp.value = (60 * 60 - remaining);
+              }
+            });
+          }
+
           // beforeunload → sendBeacon + warning
           window.addEventListener("beforeunload", (e) => {
             if (!submitted) {
               const fd = new FormData(form);
               fd.append("time_spent", 60 * 60 - remaining);
               navigator.sendBeacon(form.action, fd);
-              e.preventDefault();
+              e.preventDefault(); // This triggers the warning
               e.returnValue = "";
             }
           });


### PR DESCRIPTION
…warning

This commit addresses two issues:

1.  **500 Internal Server Error in `admin_routes.view_incorrect_answers`:**
    - Changed the query construction from `db.session.query(...)` to `IncorrectAnswer.query.with_entities(...)`. This provides a Flask-SQLAlchemy BaseQuery object, making the `.paginate()` method available and resolving the `AttributeError`.
    - The query logic now correctly uses `func.coalesce` to handle cases where associated `Exam.title` or `Question.question_text` might be NULL (e.g., for special exams, or if an exam/question was deleted), preventing errors during data retrieval.
    - The subquery `last_wrong_sq` was refined to group by `question_id`, `exam_id`, and `special_paper` to accurately identify the latest incorrect attempt for each unique question context.

2.  **"Unsaved Answers" Warning on Special Exam Submission:**
    - Modified the JavaScript in `templates/exam_paper1.html` and `templates/exam_paper2.html`.
    - Added a `submit` event listener to the `examForm`. Within this listener, the `submitted` flag is set to `true`, and the `timeSpentInput` is updated.
    - This ensures that when you legitimately submit the exam, the `beforeunload` event handler recognizes the submission as intentional and does not trigger the browser's "unsaved changes" warning.