### PR TITLE
Fix blueprint prefix duplication in routes

### DIFF
--- a/exams_routes.py
+++ b/exams_routes.py
@@ -14,7 +14,7 @@ from flask import redirect, flash, url_for
 from utils.progress_utils import has_finished_study
 
 # Blueprint setup
-exams_routes = Blueprint('exams_routes', __name__, url_prefix='/exams')
+exams_routes = Blueprint('exams_routes', __name__)
 
 # -------------------------------
 # Route to Create an Exam 

--- a/profile_routes.py
+++ b/profile_routes.py
@@ -10,7 +10,7 @@ import logging
 
 profile_routes = Blueprint('profile_routes', __name__)
 
-@profile_routes.route('/profile')
+@profile_routes.route('/')
 @login_required
 def profile():
     """
@@ -78,7 +78,7 @@ def profile():
         selected_level=selected_level
     )
 
-@profile_routes.route('/profile/edit', methods=['GET', 'POST'])
+@profile_routes.route('/edit', methods=['GET', 'POST'])
 @login_required
 def edit_profile():
     """
@@ -146,7 +146,7 @@ def edit_profile():
     )
 
 
-@profile_routes.route('/profile/delete_picture', methods=['POST'])
+@profile_routes.route('/delete_picture', methods=['POST'])
 @login_required
 def delete_profile_picture_handler():
     """

--- a/task_routes.py
+++ b/task_routes.py
@@ -17,7 +17,7 @@ import pandas as pd
 from sqlalchemy import func
 
 # Define Blueprint for task routes
-task_routes = Blueprint('task_routes', __name__, url_prefix="/tasks")
+task_routes = Blueprint('task_routes', __name__)
 
 ALLOWED_EXTENSIONS = {'pdf', 'png', 'jpg', 'jpeg', 'docx', 'xlsx'}
 MAX_FILE_SIZE = 25 * 1024 * 1024  # 25MB per file (applies to uploads in assign/edit)


### PR DESCRIPTION
## Summary
- remove url prefixes from `task_routes` and `exams_routes` blueprints
- adjust profile routes to avoid duplicated `/profile` prefix

## Testing
- `python -m py_compile exams_routes.py profile_routes.py task_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_683fff680ce883298db016ba52a7b3d0