### PR TITLE
Fix: Prevent session timeout during exams

### DIFF
--- a/app.py
+++ b/app.py
@@ -190,9 +190,18 @@ def add_security_headers(response):
 # ----------------------------------------------------------------------
 # User session timeout
 def check_afk_timeout():
-    if request.endpoint in ['static', 'auth_routes.login', 'auth_routes.logout']:
+    if request.endpoint in [
+        'static',
+        'auth_routes.login',
+        'auth_routes.logout',
+        'special_exams_routes.exam_paper1',
+        'special_exams_routes.submit_paper1',
+        'special_exams_routes.exam_paper2',
+        'special_exams_routes.submit_paper2',
+        'exams_routes.exam_page',
+        'exams_routes.submit_exam'
+    ]:
         return
-
     if 'user_id' in session:
         now = datetime.utcnow()
         last_activity = session.get('last_activity')


### PR DESCRIPTION
This commit prevents the session from timing out while you are taking an exam.

The `check_afk_timeout` function, which is called before each request, would log you out if you were inactive for more than 15 minutes. This was problematic for exams, as you could be actively working on an exam without making any requests to the server.

This commit fixes this issue by excluding all exam-related routes from the AFK check.